### PR TITLE
31 feature add timer continuance

### DIFF
--- a/source/timer-page/timer.css
+++ b/source/timer-page/timer.css
@@ -256,6 +256,7 @@ h2{
 .button-task-position{
     padding-top: 2rem;
 }
+
 .button-task{
     font-family: "Poppins", sans-serif;
     color: #ffffff;
@@ -266,4 +267,24 @@ h2{
     border-radius: 50px;
     text-align: center;
     background: #2E4756;
+}
+
+#auto-continue {
+    width: 80%;
+}
+
+#auto-continue-progress {
+    animation: increaseProgress 5s linear;
+    fill: var(--primary-color);
+    height: 100%;
+    width: 100%;
+}
+
+@keyframes increaseProgress {
+    from {
+        width: 0;
+    }
+    to {
+        width:100%;
+    }
 }

--- a/source/timer-page/timer.html
+++ b/source/timer-page/timer.html
@@ -111,9 +111,14 @@
               <button class="button-task" id="continue-btn">
                 Continue Task
               </button>
+              <svg id="auto-continue" height="30" display="none">
+                <rect id="auto-continue-progress"></rect>
+              </svg>
             </div>
             <div class="button-task-position">
-              <button class="button-task" id="change-btn">Change Task</button>
+              <button class="button-task" id="change-btn">
+                Change Task
+              </button>
             </div>
           </div>
         </div>

--- a/source/timer-page/timer.js
+++ b/source/timer-page/timer.js
@@ -106,15 +106,21 @@ function timerPageInit() {
 function timerLengthInit() {
   localStorage.setItem(
     'TimerMinutes',
-    localStorage.getItem('TimerMinutes') || 25
+    localStorage.getItem('TimerMinutes') || 1
   );
   localStorage.setItem(
     'ShortBreakMinutes',
-    localStorage.getItem('ShortBreakMinutes') || 5
+    localStorage.getItem('ShortBreakMinutes') || 1
   );
   localStorage.setItem(
     'LongBreakMinutes',
-    localStorage.getItem('LongBreakMinutes') || 15
+    localStorage.getItem('LongBreakMinutes') || 1
+  );
+
+  // Default autoContinue
+  localStorage.setItem(
+    'autoContinue',
+    localStorage.getItem('autoContinue') || 'on'
   );
 
   // render the change input's value
@@ -176,7 +182,13 @@ function resetProgressRing() {
 function displayBreakComplete() {
   const audio = new Audio('/assets/audio/break-tune.mp3');
   audio.play();
-  document.getElementById('breakCompleteModal').style.display = 'block';
+  setTimeout(() => {
+    if (localStorage.getItem('autoContinue') === 'on') {
+      continueTask();
+    } else {
+      document.getElementById('breakCompleteModal').style.display = 'block';
+    }
+  }, 2000);
 }
 
 /**
@@ -201,6 +213,9 @@ function continueTask() {
     'todayPomo',
     Number(localStorage.getItem('todayPomo')) + 1
   );
+  if (localStorage.getItem('autoContinue') === 'on') {
+    startTimer();
+  }
 }
 
 /**
@@ -233,6 +248,9 @@ function displayBreak() {
       renderTimer(localStorage.getItem('LongBreakMinutes'), 0);
     }
     document.getElementById('button-container').style.display = 'none';
+    if (localStorage.getItem('autoContinue') === 'on') {
+      startBreak();
+    }
   }, 2000);
 }
 
@@ -270,6 +288,8 @@ function startTimer() {
  * @param {integer} secs second of timer
  */
 function start(mins, secs) {
+  // mins = 0;
+  // secs = 5;
   isInSession = true;
   const startTime = new Date();
   // display correct distraction counter
@@ -357,21 +377,17 @@ function finishedTask() {
     // hide the fail modal if the timer runs out
     document.getElementById('failModal').style.display = 'none';
     isFailed = false;
+    document.getElementsByTagName('header-comp')[0].completedCycles = counter;
+    localStorage.setItem('sessionCounter', `${counter}`);
+    localStorage.setItem('distractCounter', `${todayDistract}`);
     if (counter % 4 === 0) {
-      document.getElementsByTagName('header-comp')[0].completedCycles = counter;
-      localStorage.setItem('sessionCounter', `${counter}`);
-      localStorage.setItem('distractCounter', `${todayDistract}`);
       localStorage.setItem('LongBreak', 'true');
       localStorage.setItem('ShortBreak', 'false');
-      displayBreak();
     } else {
-      document.getElementsByTagName('header-comp')[0].completedCycles = counter;
-      localStorage.setItem('sessionCounter', `${counter}`);
-      localStorage.setItem('distractCounter', `${todayDistract}`);
       localStorage.setItem('ShortBreak', 'true');
       localStorage.setItem('LongBreak', 'false');
-      displayBreak();
     }
+    displayBreak();
 
     // update progress for current task
     allTasks[currentTaskId].current += 1;

--- a/source/timer-page/timer.js
+++ b/source/timer-page/timer.js
@@ -190,17 +190,20 @@ function displayBreakComplete() {
  */
 function autoContinue() {
   if (localStorage.getItem('ShortBreak') === 'true') {
-    startBreak();
-  } else if (localStorage.getItem('LongBreak') === 'true') {
-    startBreak();
-  } else {
-    continueTask();
-    document.getElementsByTagName('header-comp')[0].completedCycles = Number(
-      localStorage.getItem('sessionCounter')
-    );
     setTimeout(() => {
+      startBreak();
+    }, 2000);
+  } else if (localStorage.getItem('LongBreak') === 'true') {
+    setTimeout(() => {
+      startBreak();
+    }, 2000);
+  } else {
+    document.getElementById('auto-continue').style.display = 'inline-block';
+    document.getElementById('continue-btn').style.display = 'none';
+    setTimeout(() => {
+      continueTask();
       startTimer();
-    });
+    }, 5500);
   }
 }
 
@@ -295,8 +298,6 @@ function startTimer() {
  * @param {integer} secs second of timer
  */
 function start(mins, secs) {
-  // mins = 0;
-  // secs = 5;
   isInSession = true;
   const startTime = new Date();
   // display correct distraction counter
@@ -402,9 +403,7 @@ function finishedTask() {
   }
 
   if (localStorage.getItem('autoContinue') === 'true') {
-    setTimeout(() => {
-      autoContinue();
-    }, 2000);
+    autoContinue();
   }
 }
 

--- a/source/timer-page/timer.js
+++ b/source/timer-page/timer.js
@@ -106,21 +106,21 @@ function timerPageInit() {
 function timerLengthInit() {
   localStorage.setItem(
     'TimerMinutes',
-    localStorage.getItem('TimerMinutes') || 1
+    localStorage.getItem('TimerMinutes') || 25
   );
   localStorage.setItem(
     'ShortBreakMinutes',
-    localStorage.getItem('ShortBreakMinutes') || 1
+    localStorage.getItem('ShortBreakMinutes') || 5
   );
   localStorage.setItem(
     'LongBreakMinutes',
-    localStorage.getItem('LongBreakMinutes') || 1
+    localStorage.getItem('LongBreakMinutes') || 15
   );
 
   // Default autoContinue
   localStorage.setItem(
     'autoContinue',
-    localStorage.getItem('autoContinue') || 'on'
+    localStorage.getItem('autoContinue') || 'false'
   );
 
   // render the change input's value
@@ -182,13 +182,26 @@ function resetProgressRing() {
 function displayBreakComplete() {
   const audio = new Audio('/assets/audio/break-tune.mp3');
   audio.play();
-  setTimeout(() => {
-    if (localStorage.getItem('autoContinue') === 'on') {
-      continueTask();
-    } else {
-      document.getElementById('breakCompleteModal').style.display = 'block';
-    }
-  }, 2000);
+  document.getElementById('breakCompleteModal').style.display = 'block';
+}
+
+/**
+ * Automatically continue to next phase
+ */
+function autoContinue() {
+  if (localStorage.getItem('ShortBreak') === 'true') {
+    startBreak();
+  } else if (localStorage.getItem('LongBreak') === 'true') {
+    startBreak();
+  } else {
+    continueTask();
+    document.getElementsByTagName('header-comp')[0].completedCycles = Number(
+      localStorage.getItem('sessionCounter')
+    );
+    setTimeout(() => {
+      startTimer();
+    });
+  }
 }
 
 /**
@@ -213,9 +226,6 @@ function continueTask() {
     'todayPomo',
     Number(localStorage.getItem('todayPomo')) + 1
   );
-  if (localStorage.getItem('autoContinue') === 'on') {
-    startTimer();
-  }
 }
 
 /**
@@ -248,9 +258,6 @@ function displayBreak() {
       renderTimer(localStorage.getItem('LongBreakMinutes'), 0);
     }
     document.getElementById('button-container').style.display = 'none';
-    if (localStorage.getItem('autoContinue') === 'on') {
-      startBreak();
-    }
   }, 2000);
 }
 
@@ -392,6 +399,12 @@ function finishedTask() {
     // update progress for current task
     allTasks[currentTaskId].current += 1;
     localStorage.setItem('allTasks', JSON.stringify(allTasks));
+  }
+
+  if (localStorage.getItem('autoContinue') === 'true') {
+    setTimeout(() => {
+      autoContinue();
+    }, 2000);
   }
 }
 


### PR DESCRIPTION
'autoContinue' setting stored in local storage toggles autoContinue mode. In autoContinue mode, the timer transitions between phases without waiting for user input.

After discussing and testing some methods for giving the user a chance to switch tasks, we landed on having the completed break modal pop up and give the user a chance to switch tasks with a progress indicator giving them a sense of how long they have before the timer automatically continues to the next phase. We discussed potentially having the continue button still appear so that users could decide to start the break manually if they wanted to skip the wait period, but ultimately this was too difficult to implement in the limited time available. 

Closes #31 